### PR TITLE
Hide ALSA errors when running an Electron app over SSH on Linux

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,6 +21,11 @@ const removeJunk = () => {
 			return false;
 		}
 
+		// Example: ALSA lib confmisc.c:767:(parse_card) cannot find card '0'
+		if (/ALSA lib [a-z]+\.c:\d+:\([a-z_]+\)/.test(chunk)) {
+			return false;
+		}
+
 		return true;
 	});
 


### PR DESCRIPTION
This can happen when running an Electron app over SSH on Linux, e.g.
```
ALSA lib confmisc.c:767:(parse_card) cannot find card '0'
ALSA lib conf.c:4568:(_snd_config_evaluate) function snd_func_card_driver returned error: No such file or directory
ALSA lib confmisc.c:392:(snd_func_concat) error evaluating strings
ALSA lib conf.c:4568:(_snd_config_evaluate) function snd_func_concat returned error: No such file or directory
ALSA lib confmisc.c:1246:(snd_func_refer) error evaluating name
ALSA lib conf.c:4568:(_snd_config_evaluate) function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5047:(snd_config_expand) Evaluate error: No such file or directory
ALSA lib pcm.c:2565:(snd_pcm_open_noupdate) Unknown PCM default
```
is being frequently printed in console.

This PR uses `/ALSA lib [a-z]+\.c:\d+:\([a-z_]+\)/` pattern to hide it.